### PR TITLE
CSVWriter: 3589 Convert values to Cells in addRow()

### DIFF
--- a/src/Spout/SpoutCSVWriter.php
+++ b/src/Spout/SpoutCSVWriter.php
@@ -2,6 +2,7 @@
 
 namespace CaT\Libs\ExcelWrapper\Spout;
 
+use Box\Spout\Common\Entity\Cell;
 use \CaT\Plugins\MateriaList\ilActions;
 use \CaT\Libs\ExcelWrapper\Writer;
 
@@ -82,7 +83,11 @@ class SpoutCSVWriter implements Writer
      */
     public function addRow(array $values): void
     {
-        $row = new Row($values, null);
+        $cells = array_map(
+            fn ($value) => new Cell($value),
+            $values
+        );
+        $row = new Row($cells, null);
         $this->writer->addRow($row);
     }
 

--- a/src/Spout/SpoutWriter.php
+++ b/src/Spout/SpoutWriter.php
@@ -115,10 +115,10 @@ class SpoutWriter implements Writer
      */
     public function addRow(array $values): void
     {
-        $cells = [];
-        foreach ($values as $value) {
-            $cells[] = new Cell($value);
-        }
+        $cells = array_map(
+            fn ($value) => new Cell($value),
+            $values
+        );
         $row = new Row($cells, $this->style);
         $this->writer->addRow($row);
     }


### PR DESCRIPTION
https://github.com/conceptsandtraining/TMS6/issues/3589

addRow() for the CSVWriter was missing the conversion of values into cells (also changed it for XLSX to make it nicer).